### PR TITLE
Fix dotenv configuration for server startup

### DIFF
--- a/unitrack/settings.py
+++ b/unitrack/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 
 import os
 from pathlib import Path
+from dotenv import load_dotenv
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -32,6 +33,7 @@ DEBUG = bool(os.environ.get("DEBUG", default=0))
 
 # 'DJANGO_ALLOWED_HOSTS' should be a single string of hosts with a space between each.
 # For example: 'DJANGO_ALLOWED_HOSTS=localhost 127.0.0.1 [::1]'
+load_dotenv(".env.dev")
 ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS").split(" ")
 
 # Application definition


### PR DESCRIPTION
This pull request addresses the bug that prevents the server from starting due to an issue with the dotenv configuration.

The server startup bug was traced to an incorrect dotenv configuration setup, specifically related to loading the .env file for development settings. This PR fixes the issue by ensuring that the dotenv configuration is properly loaded during server startup.

Changes Made:
- Added the necessary import statement for dotenv configuration.
- Corrected the dotenv file path to ".env.dev" for development settings.